### PR TITLE
The (scan list) command was throwing an exception. The error was caused

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -539,7 +539,11 @@ func toScanView(scan *scansRESTApi.ScanResponseModel) *scanView {
 	if scan.UserAgent != "" {
 		ua := user_agent.New(scan.UserAgent)
 		name, version := ua.Browser()
-		origin = name + " " + version[:strings.Index(version, ".")] // Takes the major
+		if strings.Index(version, ".") != -1 {
+			origin = name + " " + version[:strings.Index(version, ".")] // Takes the major
+		} else {
+			origin = name + " " + version
+		}
 	}
 
 	return &scanView{

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -539,7 +539,7 @@ func toScanView(scan *scansRESTApi.ScanResponseModel) *scanView {
 	if scan.UserAgent != "" {
 		ua := user_agent.New(scan.UserAgent)
 		name, version := ua.Browser()
-		if strings.Index(version, ".") != -1 {
+		if strings.Contains(version, ".") {
 			origin = name + " " + version[:strings.Index(version, ".")] // Takes the major
 		} else {
 			origin = name + " " + version


### PR DESCRIPTION
This was caused by a scan client with the version number Java 15. The code assumed all
client version numbers were going to have a (major.minor) style
and crashed trying to parse the string. The code can now handle
situations where there is a a (major.minor)version number or just a major
version number.