### PR TITLE
Feature/cli configuration

### DIFF
--- a/internal/commands/configuration.go
+++ b/internal/commands/configuration.go
@@ -14,6 +14,9 @@ func NewConfigCommand() *cobra.Command {
 	scanCmd := &cobra.Command{
 		Use:   "configure",
 		Short: "Manage scan configurations",
+		Run: func(cmd *cobra.Command, args []string) {
+			wrappers.PromptConfiguration()
+		},
 	}
 
 	storValCmd := &cobra.Command{

--- a/internal/wrappers/configuration.go
+++ b/internal/wrappers/configuration.go
@@ -7,42 +7,42 @@ import (
 	"strings"
 
 	"github.com/checkmarxDev/ast-cli/internal/params"
-	commonParams "github.com/checkmarxDev/ast-cli/internal/params"
 	"github.com/spf13/viper"
 )
 
 const defaultProfileName = "default"
+const obfuscateLimit = 4
 
 func PromptConfiguration() {
 	reader := bufio.NewReader(os.Stdin)
-	baseURI := viper.GetString(commonParams.BaseURIKey)
-	accessKeySecret := viper.GetString(commonParams.AccessKeySecretConfigKey)
-	accessKey := viper.GetString(commonParams.AccessKeyIDConfigKey)
-	fmt.Print(fmt.Sprintf("AST Base URI [%s]: ", baseURI))
+	baseURI := viper.GetString(params.BaseURIKey)
+	accessKeySecret := viper.GetString(params.AccessKeySecretConfigKey)
+	accessKey := viper.GetString(params.AccessKeyIDConfigKey)
+	fmt.Printf(fmt.Sprintf("AST Base URI [%s]: ", baseURI))
 	baseURI, _ = reader.ReadString('\n')
 	if len(baseURI) > 1 {
 		baseURI = strings.Replace(baseURI, "\n", "", -1)
 		baseURI = strings.Replace(baseURI, "\r\n", "", -1)
-		setConfigPropertyQuiet(commonParams.BaseURIKey, baseURI)
+		setConfigPropertyQuiet(params.BaseURIKey, baseURI)
 	}
-	fmt.Print(fmt.Sprintf("AST Access Key [%s]: ", obfuscateString(accessKey)))
+	fmt.Printf(fmt.Sprintf("AST Access Key [%s]: ", obfuscateString(accessKey)))
 	accessKey, _ = reader.ReadString('\n')
 	if len(accessKey) > 1 {
 		accessKey = strings.Replace(accessKey, "\n", "", -1)
 		accessKey = strings.Replace(accessKey, "\r\n", "", -1)
-		setConfigPropertyQuiet(commonParams.AccessKeyIDConfigKey, accessKey)
+		setConfigPropertyQuiet(params.AccessKeyIDConfigKey, accessKey)
 	}
-	fmt.Print(fmt.Sprintf("AST Key Secret [%s]: ", obfuscateString(accessKeySecret)))
+	fmt.Printf(fmt.Sprintf("AST Key Secret [%s]: ", obfuscateString(accessKeySecret)))
 	accessKeySecret, _ = reader.ReadString('\n')
 	if len(accessKeySecret) > 1 {
 		accessKeySecret = strings.Replace(accessKeySecret, "\n", "", -1)
 		accessKeySecret = strings.Replace(accessKeySecret, "\r\n", "", -1)
-		setConfigPropertyQuiet(commonParams.AccessKeySecretConfigKey, accessKeySecret)
+		setConfigPropertyQuiet(params.AccessKeySecretConfigKey, accessKeySecret)
 	}
 }
 
 func obfuscateString(str string) string {
-	if len(str) > 4 {
+	if len(str) > obfuscateLimit {
 		return "******" + str[len(str)-4:]
 	} else if len(str) > 1 {
 		return "******"

--- a/internal/wrappers/configuration.go
+++ b/internal/wrappers/configuration.go
@@ -1,17 +1,57 @@
 package wrappers
 
 import (
+	"bufio"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/checkmarxDev/ast-cli/internal/params"
+	commonParams "github.com/checkmarxDev/ast-cli/internal/params"
 	"github.com/spf13/viper"
 )
 
 const defaultProfileName = "default"
 
-func SetConfigProperty(propName, propValue string) {
-	fmt.Println("Setting property [", propName, "] to value [", propValue, "]")
+func PromptConfiguration() {
+	reader := bufio.NewReader(os.Stdin)
+	baseURI := viper.GetString(commonParams.BaseURIKey)
+	accessKeySecret := viper.GetString(commonParams.AccessKeySecretConfigKey)
+	accessKey := viper.GetString(commonParams.AccessKeyIDConfigKey)
+	fmt.Print(fmt.Sprintf("AST Base URI [%s]: ", baseURI))
+	baseURI, _ = reader.ReadString('\n')
+	if len(baseURI) > 1 {
+		baseURI = strings.Replace(baseURI, "\n", "", -1)
+		baseURI = strings.Replace(baseURI, "\r\n", "", -1)
+		setConfigPropertyQuiet(commonParams.BaseURIKey, baseURI)
+	}
+	fmt.Print(fmt.Sprintf("AST Access Key [%s]: ", obfuscateString(accessKey)))
+	accessKey, _ = reader.ReadString('\n')
+	if len(accessKey) > 1 {
+		accessKey = strings.Replace(accessKey, "\n", "", -1)
+		accessKey = strings.Replace(accessKey, "\r\n", "", -1)
+		setConfigPropertyQuiet(commonParams.AccessKeyIDConfigKey, accessKey)
+	}
+	fmt.Print(fmt.Sprintf("AST Key Secret [%s]: ", obfuscateString(accessKeySecret)))
+	accessKeySecret, _ = reader.ReadString('\n')
+	if len(accessKeySecret) > 1 {
+		accessKeySecret = strings.Replace(accessKeySecret, "\n", "", -1)
+		accessKeySecret = strings.Replace(accessKeySecret, "\r\n", "", -1)
+		setConfigPropertyQuiet(commonParams.AccessKeySecretConfigKey, accessKeySecret)
+	}
+}
+
+func obfuscateString(str string) string {
+	if len(str) > 4 {
+		return "******" + str[len(str)-4:]
+	} else if len(str) > 1 {
+		return "******"
+	} else {
+		return ""
+	}
+}
+
+func setConfigPropertyQuiet(propName, propValue string) {
 	viper.Set(propName, propValue)
 	// You should be able to  call WriteConfig() but it will fail if the
 	// config file doesn't already exist, this is a known viper bug.
@@ -20,6 +60,11 @@ func SetConfigProperty(propName, propValue string) {
 	if viperErr := viper.SafeWriteConfig(); viperErr != nil {
 		_ = viper.WriteConfig()
 	}
+}
+
+func SetConfigProperty(propName, propValue string) {
+	fmt.Println("Setting property [", propName, "] to value [", propValue, "]")
+	setConfigPropertyQuiet(propName, propValue)
 }
 
 func LoadConfiguration() {

--- a/internal/wrappers/configuration.go
+++ b/internal/wrappers/configuration.go
@@ -18,21 +18,21 @@ func PromptConfiguration() {
 	baseURI := viper.GetString(params.BaseURIKey)
 	accessKeySecret := viper.GetString(params.AccessKeySecretConfigKey)
 	accessKey := viper.GetString(params.AccessKeyIDConfigKey)
-	fmt.Printf(fmt.Sprintf("AST Base URI [%s]: ", baseURI))
+	fmt.Printf("AST Base URI [%s]: ", baseURI)
 	baseURI, _ = reader.ReadString('\n')
 	if len(baseURI) > 1 {
 		baseURI = strings.Replace(baseURI, "\n", "", -1)
 		baseURI = strings.Replace(baseURI, "\r\n", "", -1)
 		setConfigPropertyQuiet(params.BaseURIKey, baseURI)
 	}
-	fmt.Printf(fmt.Sprintf("AST Access Key [%s]: ", obfuscateString(accessKey)))
+	fmt.Printf("AST Access Key [%s]: ", obfuscateString(accessKey))
 	accessKey, _ = reader.ReadString('\n')
 	if len(accessKey) > 1 {
 		accessKey = strings.Replace(accessKey, "\n", "", -1)
 		accessKey = strings.Replace(accessKey, "\r\n", "", -1)
 		setConfigPropertyQuiet(params.AccessKeyIDConfigKey, accessKey)
 	}
-	fmt.Printf(fmt.Sprintf("AST Key Secret [%s]: ", obfuscateString(accessKeySecret)))
+	fmt.Printf("AST Key Secret [%s]: ", obfuscateString(accessKeySecret))
 	accessKeySecret, _ = reader.ReadString('\n')
 	if len(accessKeySecret) > 1 {
 		accessKeySecret = strings.Replace(accessKeySecret, "\n", "", -1)


### PR DESCRIPTION
(scan configure) is not interactive, it will prompt for the base-uri, key, and key-secret. 