### PR TITLE
Feature/cli http agent

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -20,6 +20,7 @@ const (
 	verboseUsage                   = "Verbose mode"
 	sourcesFlag                    = "sources"
 	sourcesFlagSh                  = "s"
+	agentFlag                      = "agent"
 	waitFlag                       = "nowait"
 	waitFlagSh                     = "w"
 	waitDelayFlag                  = "wait-delay"
@@ -103,6 +104,7 @@ func NewAstCLI(
 	rootCmd.PersistentFlags().String(baseIAMURIFlag, params.BaseIAMURI, baseIAMURIFlagUsage)
 	rootCmd.PersistentFlags().String(profileFlag, params.Profile, profileFlagUsage)
 	rootCmd.PersistentFlags().String(astTokenFlag, params.BaseURI, astTokenUsage)
+	rootCmd.PersistentFlags().String(agentFlag, params.AgentFlag, "hello")
 
 	// Bind the viper key ast_access_key_id to flag --key of the root command and
 	// to the environment variable AST_ACCESS_KEY_ID so that it will be taken from environment variables first
@@ -117,6 +119,7 @@ func NewAstCLI(
 	// Key here is the actual flag since it doesn't use an environment variable
 	_ = viper.BindPFlag(verboseFlag, rootCmd.PersistentFlags().Lookup(verboseFlag))
 	_ = viper.BindPFlag(insecureFlag, rootCmd.PersistentFlags().Lookup(insecureFlag))
+	_ = viper.BindPFlag(params.AgentNameKey, rootCmd.PersistentFlags().Lookup(agentFlag))
 
 	// Create the CLI command structure
 	scanCmd := NewScanCommand(scansWrapper, uploadsWrapper)

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -569,14 +569,7 @@ func toScanView(scan *scansRESTApi.ScanResponseModel) *scanView {
 	if scan.UserAgent != "" {
 		ua := user_agent.New(scan.UserAgent)
 		name, version := ua.Browser()
-		if strings.Contains(version, ".") {
-			//origin = name + " " + version[:strings.Index(version, ".")] // Takes the major
-			origin = name + " " + version
-			//origin = "OR here"
-		} else {
-			origin = name + " " + version
-			//origin = "here"
-		}
+		origin = name + " " + version
 	}
 
 	return &scanView{

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -74,6 +74,7 @@ func NewScanCommand(scansWrapper wrappers.ScansWrapper, uploadsWrapper wrappers.
 	createScanCmd.PersistentFlags().String(incremental, "", "Indicates if incremental scan should be performed, defaults to false.")
 	createScanCmd.PersistentFlags().String(presetName, "", "The name of the Checkmarx preset to use.")
 	createScanCmd.PersistentFlags().String(projectType, "", "Type of project: sast")
+
 	listScansCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List all scans in the system",
@@ -569,9 +570,12 @@ func toScanView(scan *scansRESTApi.ScanResponseModel) *scanView {
 		ua := user_agent.New(scan.UserAgent)
 		name, version := ua.Browser()
 		if strings.Contains(version, ".") {
-			origin = name + " " + version[:strings.Index(version, ".")] // Takes the major
+			//origin = name + " " + version[:strings.Index(version, ".")] // Takes the major
+			origin = name + " " + version
+			//origin = "OR here"
 		} else {
 			origin = name + " " + version
+			//origin = "here"
 		}
 	}
 

--- a/internal/commands/version.go
+++ b/internal/commands/version.go
@@ -3,11 +3,8 @@ package commands
 import (
 	"fmt"
 
+	"github.com/checkmarxDev/ast-cli/internal/params"
 	"github.com/spf13/cobra"
-)
-
-const (
-	version = "v2.0.0_RC2"
 )
 
 func NewVersionCommand() *cobra.Command {
@@ -15,7 +12,7 @@ func NewVersionCommand() *cobra.Command {
 		Use:   "version",
 		Short: "Prints the version number",
 		Run: func(cmd *cobra.Command, args []string) {
-			fmt.Println(version)
+			fmt.Println(params.Version)
 		},
 	}
 }

--- a/internal/params/binds.go
+++ b/internal/params/binds.go
@@ -11,6 +11,7 @@ var EnvVarsBinds = []struct {
 	{AstUsernameKey, AstUsernameEnv, ""},
 	{AstPasswordKey, AstPasswordEnv, ""},
 	{AstTokenKey, AstTokenEnv, ""},
+	{AgentNameKey, AgentNameEnv, "ASTCLI"},
 	{ScansPathKey, ScansPathEnv, "api/scans"},
 	{ProjectsPathKey, ProjectsPathEnv, "api/projects"},
 	{ResultsPathKey, ResultsPathEnv, "api/results"},

--- a/internal/params/envs.go
+++ b/internal/params/envs.go
@@ -10,6 +10,7 @@ const (
 	AccessKeyIDEnv                      = "CX_AST_ACCESS_KEY_ID"
 	AccessKeySecretEnv                  = "CX_AST_ACCESS_KEY_SECRET"
 	ScansPathEnv                        = "CX_SCANS_PATH"
+	AgentNameEnv                        = "CX_AGENT_NAME"
 	ProjectsPathEnv                     = "CX_PROJECTS_PATH"
 	ResultsPathEnv                      = "CX_RESULTS_PATH"
 	BflPathEnv                          = "CX_BFL_PATH"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -31,6 +31,11 @@ const (
 	SastALlInOne = "SAST_ALL_IN_ONE"
 	Profile      = "default"
 	BaseURI      = "127.0.0.1:80"
+	AgentFlag    = "ASTCLI"
 	BaseIAMURI   = ""
 	AstToken     = ""
+)
+
+const (
+	Version = "v2.0.0_RC4"
 )

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -37,5 +37,5 @@ const (
 )
 
 const (
-	Version = "v2.0.0_RC4"
+	Version = "2.0.0_RC4"
 )

--- a/internal/params/keys.go
+++ b/internal/params/keys.go
@@ -10,6 +10,7 @@ var (
 	AstPasswordKey                      = strings.ToLower(AstPasswordEnv)
 	AstTokenKey                         = strings.ToLower(AstTokenEnv)
 	ScansPathKey                        = strings.ToLower(ScansPathEnv)
+	AgentNameKey                        = strings.ToLower(AgentNameEnv)
 	ProjectsPathKey                     = strings.ToLower(ProjectsPathEnv)
 	ResultsPathKey                      = strings.ToLower(ResultsPathEnv)
 	BflPathKey                          = strings.ToLower(BflPathEnv)

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -47,6 +47,11 @@ const failedToAuth = "Failed to authenticate - please provide an %s"
 
 var usingProxyMsgDisplayed = false
 
+func setAgentName(req *http.Request) {
+	agentStr := viper.GetString(commonParams.AgentNameKey) + "/" + commonParams.Version
+	req.Header.Set("User-Agent", agentStr)
+}
+
 func getClient(timeout uint) *http.Client {
 	insecure := viper.GetBool("insecure")
 	proxyStr := viper.GetString(commonParams.ProxyKey)
@@ -72,10 +77,10 @@ func SendHTTPRequest(method, path string, body io.Reader, auth bool, timeout uin
 func SendHTTPRequestByFullURL(method, fullURL string, body io.Reader, auth bool, timeout uint) (*http.Response, error) {
 	client := getClient(timeout)
 	req, err := http.NewRequest(method, fullURL, body)
+	setAgentName(req)
 	if err != nil {
 		return nil, err
 	}
-
 	if auth {
 		req, err = enrichWithOath2Credentials(req)
 		if err != nil {
@@ -95,6 +100,7 @@ func SendHTTPRequestPasswordAuth(method, path string, body io.Reader, timeout ui
 	client := getClient(timeout)
 	u := GetURL(path)
 	req, err := http.NewRequest(method, u, body)
+	setAgentName(req)
 	if err != nil {
 		return nil, err
 	}
@@ -103,7 +109,6 @@ func SendHTTPRequestPasswordAuth(method, path string, body io.Reader, timeout ui
 	if err != nil {
 		return nil, err
 	}
-
 	var resp *http.Response
 	resp, err = client.Do(req)
 	if err != nil {
@@ -128,6 +133,7 @@ func SendHTTPRequestWithQueryParams(method, path string, params map[string]strin
 	client := getClient(timeout)
 	u := GetURL(path)
 	req, err := http.NewRequest(method, u, body)
+	setAgentName(req)
 	if err != nil {
 		return nil, err
 	}
@@ -283,6 +289,7 @@ func writeCredentialsToCache(credentialsFilePath string, credentialsHash uint64,
 func getNewToken(credentialsPayload, authServerURI string) (*string, error) {
 	payload := strings.NewReader(credentialsPayload)
 	req, err := http.NewRequest(http.MethodPost, authServerURI, payload)
+	setAgentName(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Modified User Agent value to default to ASTCLI. The CLI lets the user customize the agent name with the (--agent) property, this gives extensions like Jenkins the ability to send customized agent data.