### PR TITLE
Renamed CX_BASE_IAM_URIL to CX_BASE_AUTH_URI.

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -55,8 +55,8 @@ const (
 	proxyFlag                      = "proxy"
 	proxyFlagUsage                 = "Proxy server to send communication through"
 	baseURIFlagUsage               = "The base system URI"
-	baseIAMURIFlag                 = "base-auth-uri"
-	baseIAMURIFlagUsage            = "The base system IAM URI"
+	baseAuthURIFlag                = "base-auth-uri"
+	baseAuthURIFlagUsage           = "The base system IAM URI"
 	astTokenFlag                   = "token"
 	astTokenUsage                  = "The token to login to AST with"
 	repoURLFlag                    = "repo-url"
@@ -103,7 +103,7 @@ func NewAstCLI(
 	rootCmd.PersistentFlags().Bool(insecureFlag, false, insecureFlagUsage)
 	rootCmd.PersistentFlags().String(proxyFlag, "", proxyFlagUsage)
 	rootCmd.PersistentFlags().String(baseURIFlag, params.BaseURI, baseURIFlagUsage)
-	rootCmd.PersistentFlags().String(baseIAMURIFlag, params.BaseIAMURI, baseIAMURIFlagUsage)
+	rootCmd.PersistentFlags().String(baseAuthURIFlag, params.BaseIAMURI, baseAuthURIFlagUsage)
 	rootCmd.PersistentFlags().String(profileFlag, params.Profile, profileFlagUsage)
 	rootCmd.PersistentFlags().String(astTokenFlag, params.BaseURI, astTokenUsage)
 	rootCmd.PersistentFlags().String(agentFlag, params.AgentFlag, "hello")
@@ -116,7 +116,7 @@ func NewAstCLI(
 	_ = viper.BindPFlag(params.AstAuthenticationPathConfigKey, rootCmd.PersistentFlags().Lookup(astAuthenticationPathFlag))
 	_ = viper.BindPFlag(params.BaseURIKey, rootCmd.PersistentFlags().Lookup(baseURIFlag))
 	_ = viper.BindPFlag(params.ProxyKey, rootCmd.PersistentFlags().Lookup(proxyFlag))
-	_ = viper.BindPFlag(params.BaseIAMURIKey, rootCmd.PersistentFlags().Lookup(baseIAMURIFlag))
+	_ = viper.BindPFlag(params.BaseAuthURIKey, rootCmd.PersistentFlags().Lookup(baseAuthURIFlag))
 	_ = viper.BindPFlag(params.AstTokenKey, rootCmd.PersistentFlags().Lookup(astTokenFlag))
 	// Key here is the actual flag since it doesn't use an environment variable
 	_ = viper.BindPFlag(verboseFlag, rootCmd.PersistentFlags().Lookup(verboseFlag))

--- a/internal/params/binds.go
+++ b/internal/params/binds.go
@@ -7,7 +7,7 @@ var EnvVarsBinds = []struct {
 }{
 	{BaseURIKey, BaseURIEnv, "http://127.0.0.1:80"},
 	{ProxyKey, ProxyEnv, ""},
-	{BaseIAMURIKey, BaseIAMURIEnv, ""},
+	{BaseAuthURIKey, BaseAuthURIEnv, ""},
 	{AstUsernameKey, AstUsernameEnv, ""},
 	{AstPasswordKey, AstPasswordEnv, ""},
 	{AstTokenKey, AstTokenEnv, ""},

--- a/internal/params/envs.go
+++ b/internal/params/envs.go
@@ -3,7 +3,7 @@ package params
 const (
 	BaseURIEnv                          = "CX_BASE_URI"
 	ProxyEnv                            = "CX_HTTP_PROXY"
-	BaseIAMURIEnv                       = "CX_BASE_IAM_URI"
+	BaseAuthURIEnv                      = "CX_BASE_AUTH_URI"
 	AstUsernameEnv                      = "CX_AST_USERNAME"
 	AstPasswordEnv                      = "CX_AST_PASSWORD"
 	AstTokenEnv                         = "CX_TOKEN"

--- a/internal/params/keys.go
+++ b/internal/params/keys.go
@@ -5,7 +5,7 @@ import "strings"
 var (
 	BaseURIKey                          = strings.ToLower(BaseURIEnv)
 	ProxyKey                            = strings.ToLower(ProxyEnv)
-	BaseIAMURIKey                       = strings.ToLower(BaseIAMURIEnv)
+	BaseAuthURIKey                      = strings.ToLower(BaseAuthURIEnv)
 	AstUsernameKey                      = strings.ToLower(AstUsernameEnv)
 	AstPasswordKey                      = strings.ToLower(AstPasswordEnv)
 	AstTokenKey                         = strings.ToLower(AstTokenEnv)

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -98,7 +98,7 @@ func SendHTTPRequestByFullURL(method, fullURL string, body io.Reader, auth bool,
 func SendHTTPRequestPasswordAuth(method, path string, body io.Reader, timeout uint,
 	username, password, adminClientID, adminClientSecret string) (*http.Response, error) {
 	client := getClient(timeout)
-	u := GetURL(path)
+	u := GetAuthURL(path)
 	req, err := http.NewRequest(method, u, body)
 	setAgentName(req)
 	if err != nil {
@@ -122,10 +122,10 @@ func GetURL(path string) string {
 }
 
 func GetAuthURL(path string) string {
-	if viper.GetString(commonParams.BaseIAMURIKey) != "" {
-		return fmt.Sprintf("%s/%s", viper.GetString(commonParams.BaseIAMURIKey), path)
+	if viper.GetString(commonParams.BaseAuthURIKey) != "" {
+		return fmt.Sprintf("%s/%s", viper.GetString(commonParams.BaseAuthURIKey), path)
 	}
-	return ""
+	return GetURL(path)
 }
 
 func SendHTTPRequestWithQueryParams(method, path string, params map[string]string,
@@ -160,9 +160,6 @@ func getAuthURI() (string, error) {
 		return "", errors.Errorf(fmt.Sprintf(failedToAuth, "authentication path"))
 	}
 	authURI := GetAuthURL(authPath)
-	if authURI == "" {
-		authURI = GetURL(authPath)
-	}
 	authURL, err := url.Parse(authURI)
 	if err != nil {
 		return "", errors.Wrap(err, "authentication URI is not in a correct format")


### PR DESCRIPTION
This brings the CLI arg name inline with the environment variable name for consistency. 