### PR TITLE
Many small tweaks to CLI parameters:

### DIFF
--- a/internal/commands/auth.go
+++ b/internal/commands/auth.go
@@ -34,11 +34,11 @@ func NewAuthCommand(authWrapper wrappers.AuthWrapper) *cobra.Command {
 			"If you wish to use this client with the cli set those credentials as environment variables.\n" +
 			"On Linux just wrap this command with export e.g:\n" +
 			"\n" +
-			"  export $(ast auth register -u <user> -p <pass>) \n" +
+			"  export $(cx auth register -u <user> -p <pass>) \n" +
 			"\n" +
 			"On Windows you can use PowerShell e.g.:\n" +
 			"\n" +
-			"  ./ast auth register -u <user> -p <pass> | % {set-content -Path $('Env:'+$_.Split(\"=\")[0]) -Value $_.Split(\"=\")[1]}" +
+			"  ./cx auth register -u <user> -p <pass> | % {set-content -Path $('Env:'+$_.Split(\"=\")[0]) -Value $_.Split(\"=\")[1]}" +
 			"\n",
 		RunE: runRegister(authWrapper),
 	}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -2,7 +2,6 @@ package commands
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/checkmarxDev/ast-cli/internal/params"
@@ -22,6 +21,7 @@ const (
 	sourcesFlag                    = "sources"
 	sourcesFlagSh                  = "s"
 	agentFlag                      = "agent"
+	agentFlagUsage                 = "Scan origin name"
 	waitFlag                       = "nowait"
 	waitFlagSh                     = "w"
 	waitDelayFlag                  = "wait-delay"
@@ -35,11 +35,11 @@ const (
 	projectName                    = "project-name"
 	scanTypes                      = "scan-types"
 	incrementalSast                = "sast-incremental"
-	presetName                     = "preset-name"
+	presetName                     = "sast-preset-name"
 	accessKeyIDFlag                = "client-id"
 	accessKeySecretFlag            = "client-secret"
-	accessKeyIDFlagUsage           = "The access key ID"
-	accessKeySecretFlagUsage       = "The access key secret"
+	accessKeyIDFlagUsage           = "The oAuth2 client ID"
+	accessKeySecretFlagUsage       = "The oAuth2 client secret"
 	astAuthenticationPathFlag      = "auth-path"
 	astAuthenticationPathFlagUsage = "The authentication path"
 	insecureFlag                   = "insecure"
@@ -98,14 +98,15 @@ func NewAstCLI(
 	rootCmd.PersistentFlags().BoolP(verboseFlag, verboseFlagSh, false, verboseUsage)
 	rootCmd.PersistentFlags().String(accessKeyIDFlag, "", accessKeyIDFlagUsage)
 	rootCmd.PersistentFlags().String(accessKeySecretFlag, "", accessKeySecretFlagUsage)
-	rootCmd.PersistentFlags().String(astAuthenticationPathFlag, "", astAuthenticationPathFlagUsage)
+	// This may need to be enabled again
+	// rootCmd.PersistentFlags().String(astAuthenticationPathFlag, "", astAuthenticationPathFlagUsage)
 	rootCmd.PersistentFlags().Bool(insecureFlag, false, insecureFlagUsage)
 	rootCmd.PersistentFlags().String(proxyFlag, "", proxyFlagUsage)
 	rootCmd.PersistentFlags().String(baseURIFlag, params.BaseURI, baseURIFlagUsage)
 	rootCmd.PersistentFlags().String(baseAuthURIFlag, params.BaseIAMURI, baseAuthURIFlagUsage)
 	rootCmd.PersistentFlags().String(profileFlag, params.Profile, profileFlagUsage)
 	rootCmd.PersistentFlags().String(astAPIKeyFlag, params.BaseURI, astAPIKeyUsage)
-	rootCmd.PersistentFlags().String(agentFlag, params.AgentFlag, "hello")
+	rootCmd.PersistentFlags().String(agentFlag, params.AgentFlag, agentFlagUsage)
 
 	// Bind the viper key ast_access_key_id to flag --key of the root command and
 	// to the environment variable AST_ACCESS_KEY_ID so that it will be taken from environment variables first
@@ -133,74 +134,11 @@ func NewAstCLI(
 	utilsCmd := NewUtilsCommand(healthCheckWrapper, ssiWrapper, rmWrapper, logsWrapper, queriesWrapper, uploadsWrapper)
 	configCmd := NewConfigCommand()
 
-	//
-	/// Complete command
-	//
-	var completionCmd = &cobra.Command{
-		Use:   "completion [bash|zsh|fish|powershell]",
-		Short: "Generate completion script",
-		Long: `To load completions:
-	
-	Bash:
-	
-		$ source <(cx completion bash)
-	
-		# To load completions for each session, execute once:
-		# Linux:
-		$ cx completion bash > /etc/bash_completion.d/cx
-		# macOS:
-		$ cx completion bash > /usr/local/etc/bash_completion.d/cx
-	
-	Zsh:
-	
-		# If shell completion is not already enabled in your environment,
-		# you will need to enable it.  You can execute the following once:
-	
-		$ echo "autoload -U compinit; compinit" >> ~/.zshrc
-	
-		# To load completions for each session, execute once:
-		$ cx completion zsh > "${fpath[1]}/_cx"
-	
-		# You will need to start a new shell for this setup to take effect.
-	
-	fish:
-	
-		$ cx completion fish | source
-	
-		# To load completions for each session, execute once:
-		$ cx completion fish > ~/.config/fish/completions/cx.fish
-	
-	PowerShell:
-	
-		PS> cx completion powershell | Out-String | Invoke-Expression
-	
-		# To load completions for every new session, run:
-		PS> cx completion powershell > cx.ps1
-		# and source this file from your PowerShell profile.
-	`,
-		DisableFlagsInUseLine: true,
-		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
-		Args:                  cobra.ExactValidArgs(1),
-		Run: func(cmd *cobra.Command, args []string) {
-			switch args[0] {
-			case "bash":
-				cmd.Root().GenBashCompletion(os.Stdout)
-			case "zsh":
-				cmd.Root().GenZshCompletion(os.Stdout)
-			case "fish":
-				cmd.Root().GenFishCompletion(os.Stdout, true)
-			case "powershell":
-				cmd.Root().GenPowerShellCompletion(os.Stdout)
-			}
-		},
-	}
-
 	rootCmd.AddCommand(scanCmd,
 		projectCmd,
 		resultCmd,
 		versionCmd,
 		//bflCmd,
-		completionCmd,
 		authCmd,
 		utilsCmd,
 		configCmd,

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -218,18 +218,14 @@ func addSastScan(cmd *cobra.Command) map[string]interface{} {
 		objArr["type"] = "sast"
 		var valueMap map[string]interface{}
 		_ = json.Unmarshal([]byte("{}"), &valueMap)
-		foundValue := false
 		if newIncremental != "" {
-			foundValue = true
 			valueMap["incremental"] = newIncremental
 		}
 		if newPresetName != "" {
-			foundValue = true
-			valueMap["presetName"] = newPresetName
+			newPresetName = "Checkmarx Default"
 		}
-		if foundValue {
-			objArr["value"] = valueMap
-		}
+		valueMap["presetName"] = newPresetName
+		objArr["value"] = valueMap
 		return objArr
 	}
 	return nil

--- a/internal/commands/utils.go
+++ b/internal/commands/utils.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"os"
+
 	"github.com/checkmarxDev/ast-cli/internal/wrappers"
 	"github.com/spf13/cobra"
 )
@@ -21,7 +23,67 @@ func NewUtilsCommand(healthCheckWrapper wrappers.HealthCheckWrapper,
 	rmCmd := NewSastResourcesCommand(rmWrapper)
 	queriesCmd := NewQueryCommand(queriesWrapper, uploadsWrapper)
 	logsCmd := NewLogsCommand(logsWrapper)
-	configCmd := NewConfigCommand()
-	scanCmd.AddCommand(healthCheckCmd, ssiCmd, rmCmd, queriesCmd, logsCmd, configCmd)
+	//
+	/// Complete command
+	//
+	var completionCmd = &cobra.Command{
+		Use:   "completion [bash|zsh|fish|powershell]",
+		Short: "Generate completion script",
+		Long: `To load completions:
+	
+	Bash:
+	
+		$ source <(cx completion bash)
+	
+		# To load completions for each session, execute once:
+		# Linux:
+		$ cx completion bash > /etc/bash_completion.d/cx
+		# macOS:
+		$ cx completion bash > /usr/local/etc/bash_completion.d/cx
+	
+	Zsh:
+	
+		# If shell completion is not already enabled in your environment,
+		# you will need to enable it.  You can execute the following once:
+	
+		$ echo "autoload -U compinit; compinit" >> ~/.zshrc
+	
+		# To load completions for each session, execute once:
+		$ cx completion zsh > "${fpath[1]}/_cx"
+	
+		# You will need to start a new shell for this setup to take effect.
+	
+	fish:
+	
+		$ cx completion fish | source
+	
+		# To load completions for each session, execute once:
+		$ cx completion fish > ~/.config/fish/completions/cx.fish
+	
+	PowerShell:
+	
+		PS> cx completion powershell | Out-String | Invoke-Expression
+	
+		# To load completions for every new session, run:
+		PS> cx completion powershell > cx.ps1
+		# and source this file from your PowerShell profile.
+	`,
+		DisableFlagsInUseLine: true,
+		ValidArgs:             []string{"bash", "zsh", "fish", "powershell"},
+		Args:                  cobra.ExactValidArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			switch args[0] {
+			case "bash":
+				cmd.Root().GenBashCompletion(os.Stdout)
+			case "zsh":
+				cmd.Root().GenZshCompletion(os.Stdout)
+			case "fish":
+				cmd.Root().GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				cmd.Root().GenPowerShellCompletion(os.Stdout)
+			}
+		},
+	}
+	scanCmd.AddCommand(healthCheckCmd, ssiCmd, rmCmd, queriesCmd, logsCmd, completionCmd)
 	return scanCmd
 }


### PR DESCRIPTION
- (--incremental) should be (--sast-incremental)
- Scan preset is included with all json (scan create) requests. The default is provided as "Checkmarx Default" if it isn't specified with (--sast-preset-name) option.
- Removed (--configure) from (utils) but its still available from the root level
- (Auth register) help was incorrectly show "ast" as the command.
- (--agent) help name says "Scan origin name"
- (--auth-path), has been removed until we hear otherwise.
- The client ID help is now "The oAuth2 client ID"
- The client ID secret help is now "The oAuth2 client secret"
- Moved (completion) option under (utils)