### PR TITLE
Preset name wasn't allowing for overide.

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -221,7 +221,7 @@ func addSastScan(cmd *cobra.Command) map[string]interface{} {
 		if newIncremental != "" {
 			valueMap["incremental"] = newIncremental
 		}
-		if newPresetName != "" {
+		if newPresetName == "" {
 			newPresetName = "Checkmarx Default"
 		}
 		valueMap["presetName"] = newPresetName


### PR DESCRIPTION
- Preset name wasn't allowing for overide.