### PR TITLE
CLI now respects user tenant

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
           name: Publish GitHub release
           command: |
             VERSION=$(./bin/cx version)
-            VERSION="2.0.0_RC10"
+            VERSION="2.0.0_RC11"
             ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${VERSION} ./bin/
       - save_cache: # Store cache in the /go/pkg directory
           key: go-mod-v1-{{ checksum "go.sum" }}

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -20,6 +20,8 @@ const (
 	verboseUsage             = "Verbose mode"
 	sourcesFlag              = "sources"
 	sourcesFlagSh            = "s"
+	tenantFlag               = "tenant"
+	tenantFlagUsage          = "Checkmarx tenant"
 	agentFlag                = "agent"
 	agentFlagUsage           = "Scan origin name"
 	waitFlag                 = "nowait"
@@ -99,6 +101,7 @@ func NewAstCLI(
 	rootCmd.PersistentFlags().String(profileFlag, params.Profile, profileFlagUsage)
 	rootCmd.PersistentFlags().String(astAPIKeyFlag, params.BaseURI, astAPIKeyUsage)
 	rootCmd.PersistentFlags().String(agentFlag, params.AgentFlag, agentFlagUsage)
+	rootCmd.PersistentFlags().String(tenantFlag, params.Tenant, tenantFlagUsage)
 
 	// Bind the viper key ast_access_key_id to flag --key of the root command and
 	// to the environment variable AST_ACCESS_KEY_ID so that it will be taken from environment variables first
@@ -106,6 +109,7 @@ func NewAstCLI(
 	_ = viper.BindPFlag(params.AccessKeyIDConfigKey, rootCmd.PersistentFlags().Lookup(accessKeyIDFlag))
 	_ = viper.BindPFlag(params.AccessKeySecretConfigKey, rootCmd.PersistentFlags().Lookup(accessKeySecretFlag))
 	_ = viper.BindPFlag(params.BaseURIKey, rootCmd.PersistentFlags().Lookup(baseURIFlag))
+	_ = viper.BindPFlag(params.TenantKey, rootCmd.PersistentFlags().Lookup(tenantFlag))
 	_ = viper.BindPFlag(params.ProxyKey, rootCmd.PersistentFlags().Lookup(proxyFlag))
 	_ = viper.BindPFlag(params.BaseAuthURIKey, rootCmd.PersistentFlags().Lookup(baseAuthURIFlag))
 	_ = viper.BindPFlag(params.AstAPIKey, rootCmd.PersistentFlags().Lookup(astAPIKeyFlag))

--- a/internal/params/binds.go
+++ b/internal/params/binds.go
@@ -38,6 +38,7 @@ var EnvVarsBinds = []struct {
 	{AccessKeyIDConfigKey, AccessKeyIDEnv, ""},
 	{AccessKeySecretConfigKey, AccessKeySecretEnv, ""},
 	{AstAuthenticationPathConfigKey, AstAuthenticationPathEnv, "auth/realms/organization/protocol/openid-connect/token"},
+	{TenantKey, TenantEnv, "organization"},
 	{AstRoleKey, AstRoleEnv, ScaAgent},
 	{TokenExpirySecondsKey, TokenExpirySecondsEnv, "300"},
 }

--- a/internal/params/envs.go
+++ b/internal/params/envs.go
@@ -1,6 +1,7 @@
 package params
 
 const (
+	TenantEnv                           = "CX_TENANT"
 	BaseURIEnv                          = "CX_BASE_URI"
 	ProxyEnv                            = "CX_HTTP_PROXY"
 	BaseAuthURIEnv                      = "CX_BASE_AUTH_URI"

--- a/internal/params/flags.go
+++ b/internal/params/flags.go
@@ -34,8 +34,9 @@ const (
 	AgentFlag    = "ASTCLI"
 	BaseIAMURI   = ""
 	AstToken     = ""
+	Tenant       = ""
 )
 
 const (
-	Version = "2.0.0_RC10"
+	Version = "2.0.0_RC11"
 )

--- a/internal/params/keys.go
+++ b/internal/params/keys.go
@@ -3,6 +3,7 @@ package params
 import "strings"
 
 var (
+	TenantKey                           = strings.ToLower(TenantEnv)
 	BaseURIKey                          = strings.ToLower(BaseURIEnv)
 	ProxyKey                            = strings.ToLower(ProxyEnv)
 	BaseAuthURIKey                      = strings.ToLower(BaseAuthURIEnv)

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -194,7 +194,6 @@ func enrichWithOath2Credentials(request *http.Request) error {
 	} else if accessKeySecret == "" && astAPIKey == "" {
 		return errors.Errorf(fmt.Sprintf(failedToAuth, "access key secret"))
 	} else if astAPIKey == "" && accessKeyID == "" && accessKeySecret == "" {
-
 		return errors.Errorf(fmt.Sprintf(failedToAuth, "access API Key"))
 	}
 

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -157,6 +157,11 @@ func SendHTTPRequestWithQueryParams(method, path string, params map[string]strin
 
 func getAuthURI() (string, error) {
 	authPath := viper.GetString(commonParams.AstAuthenticationPathConfigKey)
+	tenant := viper.GetString(commonParams.TenantKey)
+	fmt.Println("Tenant: ", tenant)
+	authPath = strings.Replace(authPath, "organization", tenant, 1)
+	fmt.Println(authPath)
+
 	if authPath == "" {
 		return "", errors.Errorf(fmt.Sprintf(failedToAuth, "authentication path"))
 	}
@@ -189,7 +194,7 @@ func enrichWithOath2Credentials(request *http.Request) error {
 	} else if accessKeySecret == "" && astAPIKey == "" {
 		return errors.Errorf(fmt.Sprintf(failedToAuth, "access key secret"))
 	} else if astAPIKey == "" && accessKeyID == "" && accessKeySecret == "" {
-		fmt.Println("API Key not found!")
+
 		return errors.Errorf(fmt.Sprintf(failedToAuth, "access API Key"))
 	}
 

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -158,10 +158,7 @@ func SendHTTPRequestWithQueryParams(method, path string, params map[string]strin
 func getAuthURI() (string, error) {
 	authPath := viper.GetString(commonParams.AstAuthenticationPathConfigKey)
 	tenant := viper.GetString(commonParams.TenantKey)
-	fmt.Println("Tenant: ", tenant)
 	authPath = strings.Replace(authPath, "organization", tenant, 1)
-	fmt.Println(authPath)
-
 	if authPath == "" {
 		return "", errors.Errorf(fmt.Sprintf(failedToAuth, "authentication path"))
 	}

--- a/internal/wrappers/configuration.go
+++ b/internal/wrappers/configuration.go
@@ -23,6 +23,8 @@ func PromptConfiguration() {
 	accessKeySecret := viper.GetString(params.AccessKeySecretConfigKey)
 	accessKey := viper.GetString(params.AccessKeyIDConfigKey)
 	accessAPIKey := viper.GetString(params.AstAPIKey)
+	tenant := viper.GetString(params.TenantKey)
+	// Prompt for Base URI
 	fmt.Printf("AST Base URI [%s]: ", baseURI)
 	baseURI, _ = reader.ReadString('\n')
 	baseURI = strings.Replace(baseURI, "\n", "", -1)
@@ -40,6 +42,14 @@ func PromptConfiguration() {
 	baseAuthURI = strings.Replace(baseAuthURI, "\r", "", -1)
 	if len(baseAuthURI) > 0 {
 		setConfigPropertyQuiet(params.BaseAuthURIKey, baseAuthURI)
+	}
+	// Prompt for tenant name
+	fmt.Printf("AST Tenant [%s]: ", tenant)
+	tenant, _ = reader.ReadString('\n')
+	tenant = strings.Replace(tenant, "\n", "", -1)
+	tenant = strings.Replace(tenant, "\r", "", -1)
+	if len(tenant) > 0 {
+		setConfigPropertyQuiet(params.TenantKey, tenant)
 	}
 	// Prompt for access credentials type
 	fmt.Printf("Do you want to use API Key authentication? (Y/N): ")


### PR DESCRIPTION
- When authenticating CLI now respects user tenant
- Added environment variable CX_TENANT
- Added global CLI argument (--tenant)
- Added tenant name to (configure) command menu
- Updated version to RC11