### PR TITLE
Added (--scan-id) and (--project-id) arguments to CLI commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,6 +339,31 @@ You can disable polling mode like this:
 ./cx scan create -s <your-repo-url> --project-name "testproj" --scan-types "sast" --nowait true
 ```
 
+You can view the information about a scan like this:
+
+``` bash
+./cx scan show --scan-id <scan-id>
+```
+
+You can cancel running scans like this:
+
+``` bash
+# Cancel a single scan
+./cx scan cancel --scan-id <scan-id>
+# Cancel multiple scans at once
+./cx scan cancel --scan-id <scan-id>,<scan-id>,etc
+```
+
+You can delete existing scan like this:
+
+``` bash
+# Delete a single scan
+./cx scan delete --scan-id <scan-id>
+# Cancel multiple scans at once
+./cx scan delete --scan-id <scan-id>,<scan-id>,etc
+```
+
+
 
 ## Managing Projects
 
@@ -369,7 +394,7 @@ Project ID       Name       Created at          Updated at
 You can show the details about a specific project like this:
 
 ``` bash
-./cx project list <your-project-id>
+./cx project show --project-id <your-project-id>
 
 Project ID       Name       Created at          Updated at          Tags Groups 
 ----------       ----       ----------          ----------          ---- ------ 
@@ -379,7 +404,7 @@ Project ID       Name       Created at          Updated at
 Finally you can delete a project like this:
 
 ``` bash
-./cx project delete <your-project-id>
+./cx project delete --project-id <your-project-id>
 ```
 
 

--- a/internal/commands/project.go
+++ b/internal/commands/project.go
@@ -56,16 +56,18 @@ func NewProjectCommand(projectsWrapper wrappers.ProjectsWrapper) *cobra.Command 
 	listProjectsCmd.PersistentFlags().StringSlice(filterFlag, []string{}, filterProjectsListFlagUsage)
 
 	showProjectCmd := &cobra.Command{
-		Use:   "show <project-id>",
+		Use:   "show",
 		Short: "Show information about a project",
 		RunE:  runGetProjectByIDCommand(projectsWrapper),
 	}
+	addProjectIDFlag(showProjectCmd, "Project ID to show.")
 
 	deleteProjCmd := &cobra.Command{
-		Use:   "delete <project-id>",
+		Use:   "delete",
 		Short: "Delete a project",
 		RunE:  runDeleteProjectCommand(projectsWrapper),
 	}
+	addProjectIDFlag(deleteProjCmd, "Project ID to delete.")
 
 	tagsCmd := &cobra.Command{
 		Use:   "tags",
@@ -170,10 +172,10 @@ func runGetProjectByIDCommand(projectsWrapper wrappers.ProjectsWrapper) func(cmd
 		var projectResponseModel *projectsRESTApi.ProjectResponseModel
 		var errorModel *projectsRESTApi.ErrorModel
 		var err error
-		if len(args) == 0 {
+		projectID, _ := cmd.Flags().GetString(projectIDFlag)
+		if projectID == "" {
 			return errors.Errorf("%s: Please provide a project ID", failedGettingProj)
 		}
-		projectID := args[0]
 		projectResponseModel, errorModel, err = projectsWrapper.GetByID(projectID)
 		if err != nil {
 			return errors.Wrapf(err, "%s", failedGettingProj)
@@ -195,10 +197,10 @@ func runDeleteProjectCommand(projectsWrapper wrappers.ProjectsWrapper) func(cmd 
 	return func(cmd *cobra.Command, args []string) error {
 		var errorModel *projectsRESTApi.ErrorModel
 		var err error
-		if len(args) == 0 {
+		projectID, _ := cmd.Flags().GetString(projectIDFlag)
+		if projectID == "" {
 			return errors.Errorf("%s: Please provide a project ID", failedDeletingProj)
 		}
-		projectID := args[0]
 		errorModel, err = projectsWrapper.Delete(projectID)
 		if err != nil {
 			return errors.Wrapf(err, "%s\n", failedDeletingProj)

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -29,6 +29,8 @@ const (
 	waitDelayFlag            = "wait-delay"
 	sourceDirFilterFlag      = "filter"
 	sourceDirFilterFlagSh    = "f"
+	scanIDFlag               = "scan-id"
+	projectIDFlag            = "project-id"
 	branchFlag               = "branch"
 	branchFlagSh             = "b"
 	branchFlagUsage          = "Branch to scan"
@@ -187,6 +189,14 @@ func addFormatFlagToMultipleCommands(cmds []*cobra.Command, defaultFormat string
 func addFormatFlag(cmd *cobra.Command, defaultFormat string, otherAvailableFormats ...string) {
 	cmd.PersistentFlags().String(formatFlag, defaultFormat,
 		fmt.Sprintf(formatFlagUsageFormat, append(otherAvailableFormats, defaultFormat)))
+}
+
+func addScanIDFlag(cmd *cobra.Command, helpMsg string) {
+	cmd.PersistentFlags().String(scanIDFlag, "", helpMsg)
+}
+
+func addProjectIDFlag(cmd *cobra.Command, helpMsg string) {
+	cmd.PersistentFlags().String(projectIDFlag, "", helpMsg)
 }
 
 func printByFormat(cmd *cobra.Command, view interface{}) error {


### PR DESCRIPTION
- The scan commands (show, delete and cancel) required Scan ID values be passed as an additiona argument. The changes to the help system prevented that argument from being input though. These commands now accept a CLI argument named (--scan-id) to prevent this issue.
- The project commands (show, delete) required Project ID values be passed as an additiona argument. The changes to the help system prevented that argument from being input though. These commands now accept a CLI argument named (--project-id) to prevent this issue.
- Updated documentation to reflect changes to scan and project commands.