### PR TITLE
Added step to check the scan status and exit

### DIFF
--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -503,7 +503,12 @@ func isScanRunning(scansWrapper wrappers.ScansWrapper, scanID string) bool {
 			return true
 		}
 	}
+	if scanResponseModel.Status != "Completed" {
+		fmt.Println("Scan Finished with status: ", scanResponseModel.Status)
+		os.Exit(1)
+	}
 	fmt.Println("Scan finished, final status: ", scanResponseModel.Status)
+
 	return false
 }
 


### PR DESCRIPTION
- When a scan is created in wait-mode and failed, we are not returning any exit code

Added the step to check the status of the scan and return exit code 1 when the status is not "Completed"