### PR TITLE
- Corrected basic auth proxy issue, the proxy was being used even whe…

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -38,6 +38,7 @@ const (
 	projectName              = "project-name"
 	scanTypes                = "scan-types"
 	tagList                  = "tags"
+	groupList                = "groups"
 	incrementalSast          = "sast-incremental"
 	presetName               = "sast-preset-name"
 	accessKeyIDFlag          = "client-id"

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -209,11 +209,11 @@ func updateScanRequestValues(input *[]byte, cmd *cobra.Command, sourceType strin
 	if sastConfig != nil {
 		configArr = append(configArr, sastConfig)
 	}
-	var kicsConfig map[string]interface{} = addKicsScan(cmd)
+	var kicsConfig map[string]interface{} = addKicsScan()
 	if kicsConfig != nil {
 		configArr = append(configArr, kicsConfig)
 	}
-	var scaConfig map[string]interface{} = addScaScan(cmd)
+	var scaConfig map[string]interface{} = addScaScan()
 	if scaConfig != nil {
 		configArr = append(configArr, scaConfig)
 	}
@@ -276,7 +276,7 @@ func addSastScan(cmd *cobra.Command) map[string]interface{} {
 	return nil
 }
 
-func addKicsScan(cmd *cobra.Command) map[string]interface{} {
+func addKicsScan() map[string]interface{} {
 	if scanTypeEnabled("kics") {
 		var objArr map[string]interface{}
 		_ = json.Unmarshal([]byte("{}"), &objArr)
@@ -292,7 +292,7 @@ func addKicsScan(cmd *cobra.Command) map[string]interface{} {
 	return nil
 }
 
-func addScaScan(cmd *cobra.Command) map[string]interface{} {
+func addScaScan() map[string]interface{} {
 	if scanTypeEnabled("sca") {
 		var objArr map[string]interface{}
 		_ = json.Unmarshal([]byte("{}"), &objArr)

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -244,7 +244,7 @@ func validateScanTypes() {
 	}
 }
 
-func scanTypeEnabled(cmd *cobra.Command, scanType string) bool {
+func scanTypeEnabled(scanType string) bool {
 	scanTypes := strings.Split(actualScanTypes, ",")
 	for _, a := range scanTypes {
 		if strings.EqualFold(strings.TrimSpace(a), scanType) {
@@ -255,7 +255,7 @@ func scanTypeEnabled(cmd *cobra.Command, scanType string) bool {
 }
 
 func addSastScan(cmd *cobra.Command) map[string]interface{} {
-	if scanTypeEnabled(cmd, "sast") {
+	if scanTypeEnabled("sast") {
 		var objArr map[string]interface{}
 		_ = json.Unmarshal([]byte("{}"), &objArr)
 		newIncremental, _ := cmd.Flags().GetString(incrementalSast)
@@ -277,7 +277,7 @@ func addSastScan(cmd *cobra.Command) map[string]interface{} {
 }
 
 func addKicsScan(cmd *cobra.Command) map[string]interface{} {
-	if scanTypeEnabled(cmd, "kics") {
+	if scanTypeEnabled("kics") {
 		var objArr map[string]interface{}
 		_ = json.Unmarshal([]byte("{}"), &objArr)
 		objArr["type"] = "kics"
@@ -293,7 +293,7 @@ func addKicsScan(cmd *cobra.Command) map[string]interface{} {
 }
 
 func addScaScan(cmd *cobra.Command) map[string]interface{} {
-	if scanTypeEnabled(cmd, "sca") {
+	if scanTypeEnabled("sca") {
 		var objArr map[string]interface{}
 		_ = json.Unmarshal([]byte("{}"), &objArr)
 		objArr["type"] = "sca"

--- a/internal/wrappers/client.go
+++ b/internal/wrappers/client.go
@@ -63,9 +63,16 @@ func getClient(timeout uint) *http.Client {
 func basicProxyClient(timeout uint, proxyStr string) *http.Client {
 	insecure := viper.GetBool("insecure")
 	u, _ := url.Parse(proxyStr)
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
-		Proxy:           http.ProxyURL(u),
+	var tr *http.Transport
+	if len(proxyStr) > 0 {
+		tr = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+			Proxy:           http.ProxyURL(u),
+		}
+	} else {
+		tr = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: insecure},
+		}
 	}
 	return &http.Client{Transport: tr, Timeout: time.Duration(timeout) * time.Second}
 }


### PR DESCRIPTION
- Corrected basic auth proxy issue, the proxy was being used even when not specified.
- Invalid scan types fail now on (scan create)
- If no scan types are passed to (scan create) then all scan types are assumed
- When using (project create) you can now use (--tags) option
- When using (project create) you can now use (--groups) option