### PR TITLE
Feature/ast 4445/enrich results structure

### DIFF
--- a/internal/commands/result.go
+++ b/internal/commands/result.go
@@ -28,67 +28,24 @@ const (
 	sastTypeFlag         = "sast"
 )
 
-type ScanResults struct {
-	Version string       `json:"version"`
-	Results []ScanResult `json:"results"`
-}
-
-type ScanResult struct {
-	ID             string         `json:"id"`
-	SimilarityID   string         `json:"similarityId"`
-	Severity       string         `json:"severity"`
-	Type           string         `json:"type"`
-	Status         string         `json:"status"`
-	State          string         `json:"state"`
-	ScanResultData ScanResultData `json:"data"`
-}
-
-type ScanResultData struct {
-	Comments  string               `json:"comments"`
-	QueryName string               `json:"queryName"`
-	Nodes     []ScanResultDataNode `json:"nodes"`
-}
-
-type ScanResultDataNode struct {
-	Column     string `json:"column"`
-	FileName   string `json:"fileName"`
-	FullName   string `json:"fullName"`
-	Name       string `json:"name"`
-	Line       string `json:"line"`
-	MethodLine string `json:"methodLine"`
-}
-
-type SimpleScanResult struct {
-	ID             string `json:"id"`
-	SimilarityID   string `json:"similarityId"`
-	Type           string `json:"type"`
-	Status         string `json:"status"`
-	State          string `json:"state"`
-	ScanResultData string `json:"data"`
-	Severity       string `json:"severity"`
-	Column         string `json:"column"`
-	FileName       string `json:"fileName"`
-	FullName       string `json:"fullName"`
-	Name           string `json:"name"`
-	Line           string `json:"line"`
-	MethodLine     string `json:"methodLine"`
-	Comments       string `json:"comments"`
-	QueryName      string `json:"queryName"`
-}
-
 var (
-	filterResultsListFlagUsage = fmt.Sprintf("Filter the list of results. Use ';' as the delimeter for arrays. Available filters are: %s",
-		strings.Join([]string{
-			commonParams.ScanIDQueryParam,
-			commonParams.LimitQueryParam,
-			commonParams.OffsetQueryParam,
-			commonParams.SortQueryParam,
-			commonParams.IncludeNodesQueryParam,
-			commonParams.NodeIDsQueryParam,
-			commonParams.QueryQueryParam,
-			commonParams.GroupQueryParam,
-			commonParams.StatusQueryParam,
-			commonParams.SeverityQueryParam}, ","))
+	filterResultsListFlagUsage = fmt.Sprintf(
+		"Filter the list of results. Use ';' as the delimeter for arrays. Available filters are: %s",
+		strings.Join(
+			[]string{
+				commonParams.ScanIDQueryParam,
+				commonParams.LimitQueryParam,
+				commonParams.OffsetQueryParam,
+				commonParams.SortQueryParam,
+				commonParams.IncludeNodesQueryParam,
+				commonParams.NodeIDsQueryParam,
+				commonParams.QueryQueryParam,
+				commonParams.GroupQueryParam,
+				commonParams.StatusQueryParam,
+				commonParams.SeverityQueryParam,
+			}, ",",
+		),
+	)
 	scanAPIPath = ""
 )
 
@@ -150,7 +107,10 @@ func getScanInfo(scanID string) (*ResultSummary, error) {
 	return nil, err
 }
 
-func runGetSummaryByScanIDCommand(resultsWrapper wrappers.ResultsWrapper) func(cmd *cobra.Command, args []string) error {
+func runGetSummaryByScanIDCommand(resultsWrapper wrappers.ResultsWrapper) func(
+	cmd *cobra.Command,
+	args []string,
+) error {
 	return func(cmd *cobra.Command, args []string) error {
 		targetFile, _ := cmd.Flags().GetString(TargetFlag)
 		scanID, _ := cmd.Flags().GetString(ScanIDFlag)
@@ -279,9 +239,11 @@ func runGetResultByScanIDCommand(resultsWrapper wrappers.ResultsWrapper) func(cm
 	}
 }
 
-func ReadResults(resultsWrapper wrappers.ResultsWrapper,
+func ReadResults(
+	resultsWrapper wrappers.ResultsWrapper,
 	scanID string,
-	params map[string]string) (results *wrappers.ScanResultsCollection, err error) {
+	params map[string]string,
+) (results *wrappers.ScanResultsCollection, err error) {
 	var resultsModel *wrappers.ScanResultsCollection
 	var errorModel *resultsHelpers.WebError
 	params[commonParams.ScanIDQueryParam] = scanID

--- a/internal/wrappers/results-json.go
+++ b/internal/wrappers/results-json.go
@@ -11,20 +11,20 @@ type ScanResultsCollection struct {
 type ScanResult struct {
 	Type                 string               `json:"type,omitempty"`
 	ID                   string               `json:"id,omitempty"`
-	SimilarityID         string               `json:"similarityID,omitempty"`
+	SimilarityID         string               `json:"similarityId,omitempty"`
 	Status               string               `json:"status,omitempty"`
 	State                string               `json:"state,omitempty"`
 	Severity             string               `json:"severity,omitempty"`
+	Created              string               `json:"created,omitempty"`
 	FirstFoundAt         string               `json:"firstFoundAt,omitempty"`
 	FoundAt              string               `json:"foundAt,omitempty"`
 	FirstScan            string               `json:"firstScan,omitempty"`
-	FirstScanID          string               `json:"firstScanID,omitempty"`
+	FirstScanID          string               `json:"firstScanId,omitempty"`
 	PublishedAt          string               `json:"publishedAt,omitempty"`
-	Created              string               `json:"created,omitempty"`
 	Recommendations      string               `json:"recommendations,omitempty"`
-	Comments             ResultComments       `json:"Comments,omitempty"`
-	VulnerabilityDetails VulnerabilityDetails `json:"vulnerabilityDetails,omitempty"`
 	ScanResultData       ScanResultData       `json:"data,omitempty"`
+	Comments             ResultComments       `json:"comments,omitempty"`
+	VulnerabilityDetails VulnerabilityDetails `json:"vulnerabilityDetails,omitempty"`
 }
 
 type ResultComments struct {
@@ -32,11 +32,11 @@ type ResultComments struct {
 }
 
 type VulnerabilityDetails struct {
+	CweID       int               `json:"cweId,omitempty"`
 	CvssScore   float64           `json:"cvssScore,omitempty"`
 	CveName     string            `json:"cveName,omitempty"`
 	CVSS        VulnerabilityCVSS `json:"cvss,omitempty"`
 	Compliances []*string         `json:"compliances,omitempty"`
-	// CweID       string            `json:"cweId,string"`
 }
 
 type VulnerabilityCVSS struct {
@@ -48,16 +48,19 @@ type VulnerabilityCVSS struct {
 }
 
 type ScanResultNode struct {
-	ID         string `json:"id,omitempty"`
-	Line       int    `json:"line,omitempty"`
-	Name       string `json:"name,omitempty"`
-	Column     int    `json:"column,omitempty"`
-	Length     int    `json:"length,omitempty"`
-	NodeID     int    `json:"nodeID,omitempty"`
-	DomType    string `json:"domType,omitempty"`
-	FileName   string `json:"fileName,omitempty"`
-	FullName   string `json:"fullName,omitempty"`
-	MethodLine int    `json:"methodLine,omitempty"`
+	ID          string `json:"id,omitempty"`
+	Line        uint   `json:"line,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Column      uint   `json:"column,omitempty"`
+	Length      uint   `json:"length,omitempty"`
+	Method      string `json:"method,omitempty"`
+	NodeID      int    `json:"nodeID,omitempty"`
+	DomType     string `json:"domType,omitempty"`
+	FileName    string `json:"fileName,omitempty"`
+	FullName    string `json:"fullName,omitempty"`
+	TypeName    string `json:"typeName,omitempty"`
+	MethodLine  uint   `json:"methodLine,omitempty"`
+	Definitions string `json:"definitions,omitempty"`
 }
 
 type ScanResultPackageData struct {
@@ -67,7 +70,7 @@ type ScanResultPackageData struct {
 }
 
 type ScanResultData struct {
-	QueryID      int                      `json:"queryIDFoo,omitempty"`
+	QueryID      uint64                   `json:"queryId,omitempty"`
 	QueryName    string                   `json:"queryName,omitempty"`
 	Group        string                   `json:"group,omitempty"`
 	ResultHash   string                   `json:"resultHash,omitempty"`

--- a/internal/wrappers/results-json.go
+++ b/internal/wrappers/results-json.go
@@ -32,7 +32,7 @@ type ResultComments struct {
 }
 
 type VulnerabilityDetails struct {
-	CweID       int               `json:"cweId,omitempty"`
+	CweID       interface{}       `json:"cweId,omitempty"`
 	CvssScore   float64           `json:"cvssScore,omitempty"`
 	CveName     string            `json:"cveName,omitempty"`
 	CVSS        VulnerabilityCVSS `json:"cvss,omitempty"`
@@ -70,7 +70,7 @@ type ScanResultPackageData struct {
 }
 
 type ScanResultData struct {
-	QueryID      uint64                   `json:"queryId,omitempty"`
+	QueryID      interface{}              `json:"queryId,omitempty"`
 	QueryName    string                   `json:"queryName,omitempty"`
 	Group        string                   `json:"group,omitempty"`
 	ResultHash   string                   `json:"resultHash,omitempty"`

--- a/internal/wrappers/results-sarif.go
+++ b/internal/wrappers/results-sarif.go
@@ -22,12 +22,12 @@ type SarifDriver struct {
 }
 
 type SarifDriverRule struct {
-	ID   int    `json:"id"`
+	ID   uint64 `json:"id"`
 	Name string `json:"name"`
 }
 
 type SarifScanResult struct {
-	RuleID              int                    `json:"ruleId"`
+	RuleID              uint64                 `json:"ruleId"`
 	Message             SarifMessage           `json:"message"`
 	PartialFingerprints SarifResultFingerprint `json:"partialFingerprints"`
 	Locations           []SarifLocation        `json:"locations"`
@@ -43,9 +43,9 @@ type SarifPhysicalLocation struct {
 }
 
 type SarifRegion struct {
-	StartLine   int `json:"startLine"`
-	StartColumn int `json:"startColumn"`
-	EndColumn   int `json:"endColumn"`
+	StartLine   uint `json:"startLine"`
+	StartColumn uint `json:"startColumn"`
+	EndColumn   uint `json:"endColumn"`
 }
 
 type SarifArtifactLocation struct {

--- a/internal/wrappers/results-sarif.go
+++ b/internal/wrappers/results-sarif.go
@@ -22,12 +22,12 @@ type SarifDriver struct {
 }
 
 type SarifDriverRule struct {
-	ID   uint64 `json:"id"`
-	Name string `json:"name"`
+	ID   interface{} `json:"id"`
+	Name string      `json:"name"`
 }
 
 type SarifScanResult struct {
-	RuleID              uint64                 `json:"ruleId"`
+	RuleID              interface{}            `json:"ruleId"`
 	Message             SarifMessage           `json:"message"`
 	PartialFingerprints SarifResultFingerprint `json:"partialFingerprints"`
 	Locations           []SarifLocation        `json:"locations"`


### PR DESCRIPTION
This PR adds missing fields to the results structure in the CLI.

CweID and QueryID are set as interface{} as different engines return it with different types (string vs int)