### PR TITLE
Feature/sca resolver

### DIFF
--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -49,7 +49,7 @@ const (
 	GroupList                = "groups"
 	IncrementalSast          = "sast-incremental"
 	PresetName               = "sast-preset-name"
-	ScaResolver              = "sca-resolver"
+	ScaResolverFlag          = "sca-resolver"
 	AccessKeyIDFlag          = "client-id"
 	AccessKeySecretFlag      = "client-secret"
 	AccessKeyIDFlagUsage     = "The OAuth2 client ID"

--- a/internal/commands/root.go
+++ b/internal/commands/root.go
@@ -49,6 +49,7 @@ const (
 	GroupList                = "groups"
 	IncrementalSast          = "sast-incremental"
 	PresetName               = "sast-preset-name"
+	ScaResolver              = "sca-resolver"
 	AccessKeyIDFlag          = "client-id"
 	AccessKeySecretFlag      = "client-secret"
 	AccessKeyIDFlagUsage     = "The OAuth2 client ID"

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -281,7 +281,6 @@ func scanCreateSubCommand(
 	}
 	createScanCmd.PersistentFlags().String(IncrementalSast, "false", "Incremental SAST scan should be performed.")
 	createScanCmd.PersistentFlags().String(PresetName, "", "The name of the Checkmarx preset to use.")
-	//createScanCmd.PersistentFlags().BoolP(ScaResolver, "", false, "Resolve SCA project dependencies (default true)")
 	createScanCmd.PersistentFlags().String(ScaResolverFlag, "", "Resolve SCA project dependencies (default true)")
 	createScanCmd.PersistentFlags().String(ScanTypes, "", "Scan types, ex: (sast,kics,sca)")
 	createScanCmd.PersistentFlags().String(TagList, "", "List of tags, ex: (tagA,tagB:val,etc)")
@@ -672,8 +671,7 @@ func determineSourceFile(uploadsWrapper wrappers.UploadsWrapper,
 	sourcesFile,
 	sourceDir,
 	sourceDirFilter,
-	userIncludeFilter,
-	scaResolver string) (string, error) {
+	userIncludeFilter string) (string, error) {
 	var err error
 	var preSignedURL string
 	if sourceDir != "" {
@@ -735,7 +733,6 @@ func runCreateScanCommand(scansWrapper wrappers.ScansWrapper,
 		}
 		noWaitFlag, _ := cmd.Flags().GetBool(WaitFlag)
 		waitDelay, _ := cmd.Flags().GetInt(WaitDelayFlag)
-		scaResolver, _ := cmd.Flags().GetString(ScaResolverFlag)
 		var uploadType string
 		if sourceDir != "" || sourcesFile != "" {
 			uploadType = "upload"
@@ -755,7 +752,7 @@ func runCreateScanCommand(scansWrapper wrappers.ScansWrapper,
 		// Setup the project handler (either git or upload)
 		pHandler := scansRESTApi.UploadProjectHandler{}
 		pHandler.Branch = viper.GetString(commonParams.BranchKey)
-		pHandler.UploadURL, err = determineSourceFile(uploadsWrapper, sourcesFile, sourceDir, sourceDirFilter, userIncludeFilter, scaResolver)
+		pHandler.UploadURL, err = determineSourceFile(uploadsWrapper, sourcesFile, sourceDir, sourceDirFilter, userIncludeFilter)
 		pHandler.RepoURL = scanRepoURL
 		scanModel.Handler, _ = json.Marshal(pHandler)
 		if err != nil {

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -641,10 +641,19 @@ func runScaResolver(sourceDir string) {
 		if err != nil {
 			log.Fatal(err)
 		}
-		out, err := exec.Command(scaToolPath, "offline", "-s", sourceDir, "-n", ProjectName, "-r", scaResolverResultsFile).Output()
-		fmt.Println(string(out))
-		if err != nil {
-			log.Fatal(err)
+		if scaToolPath != "nop" {
+			out, err := exec.Command(scaToolPath, "offline", "-s", sourceDir, "-n", ProjectName, "-r", scaResolverResultsFile).Output()
+			fmt.Println(string(out))
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			fmt.Println("Creating 'No Op' resolver file.")
+			d1 := []byte("{}")
+			err := os.WriteFile(scaResolverResultsFile, d1, 0644)
+			if err != nil {
+				log.Fatal(err)
+			}
 		}
 	}
 }

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/checkmarxDev/ast-cli/internal/commands/util"
-	"github.com/checkmarxDev/ast-cli/internal/params"
 	"github.com/pkg/errors"
 
 	"github.com/MakeNowJust/heredoc"
@@ -629,10 +628,9 @@ func filterMatched(filters []string, fileName string) bool {
 }
 
 func runScaResolver(scaResolverFlag bool, sourceDir string) {
-	scaToolPath := viper.GetString(params.ScaToolKey)
+	scaToolPath := viper.GetString(commonParams.ScaToolKey)
 	if len(scaToolPath) > 0 && scaResolverFlag {
 		fmt.Println("Using SCA resolver: " + scaToolPath)
-		ioutil.TempDir("", "")
 		scaFile, err := ioutil.TempFile("", "sca")
 		scaResolverResultsFile = scaFile.Name() + ".json"
 		if err != nil {
@@ -729,9 +727,9 @@ func runCreateScanCommand(scansWrapper wrappers.ScansWrapper,
 		if err != nil {
 			return errors.Wrapf(err, "%s: Input in bad format", failedCreating)
 		}
-		noWaitFlag, _ := cmd.Flags().GetBool(ScaResolver)
-		scaResolverFlag, _ := cmd.Flags().GetBool(ScaResolver)
+		noWaitFlag, _ := cmd.Flags().GetBool(WaitFlag)
 		waitDelay, _ := cmd.Flags().GetInt(WaitDelayFlag)
+		scaResolverFlag, _ := cmd.Flags().GetBool(ScaResolver)
 		var uploadType string
 		if sourceDir != "" || sourcesFile != "" {
 			uploadType = "upload"

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -647,13 +647,13 @@ func runScaResolver(scaResolverFlag bool, sourceDir string) {
 }
 
 func addScaResults(zipWriter *zip.Writer) error {
-	fmt.Println("Included SCA Results: ", "sca-results.json")
+	fmt.Println("Included SCA Results: ", "cxsca-results.json")
 	dat, err := ioutil.ReadFile(scaResolverResultsFile)
 	os.Remove(scaResolverResultsFile)
 	if err != nil {
 		return err
 	}
-	f, err := zipWriter.Create("/sca-results.json")
+	f, err := zipWriter.Create("/cxsca-results.json")
 	if err != nil {
 		return err
 	}

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -676,8 +676,6 @@ func determineSourceFile(uploadsWrapper wrappers.UploadsWrapper,
 		runScaResolver(scaResolverFlag, sourceDir)
 		sourcesFile, _ = compressFolder(sourceDir, sourceDirFilter, userIncludeFilter, scaResolverFlag)
 	}
-	fmt.Println("Sources: ", sourcesFile)
-	os.Exit(0)
 	if sourcesFile != "" {
 		// Send a request to uploads service
 		var preSignedURL *string

--- a/internal/commands/scan.go
+++ b/internal/commands/scan.go
@@ -659,13 +659,13 @@ func runScaResolver(sourceDir string) {
 }
 
 func addScaResults(zipWriter *zip.Writer) error {
-	fmt.Println("Included SCA Results: ", "cxsca-results.json")
+	fmt.Println("Included SCA Results: ", ".cxsca-results.json")
 	dat, err := ioutil.ReadFile(scaResolverResultsFile)
 	os.Remove(scaResolverResultsFile)
 	if err != nil {
 		return err
 	}
-	f, err := zipWriter.Create("/cxsca-results.json")
+	f, err := zipWriter.Create(".cxsca-results.json")
 	if err != nil {
 		return err
 	}

--- a/internal/params/binds.go
+++ b/internal/params/binds.go
@@ -11,6 +11,7 @@ var EnvVarsBinds = []struct {
 	{ProxyDomainKey, ProxyDomainEnv, ""},
 	{BaseAuthURIKey, BaseAuthURIEnv, ""},
 	{AstAPIKey, AstAPIKeyEnv, ""},
+	{ScaToolKey, ScaToolEnv, ""},
 	{AgentNameKey, AgentNameEnv, "ASTCLI"},
 	{ScansPathKey, ScansPathEnv, "api/scans"},
 	{ProjectsPathKey, ProjectsPathEnv, "api/projects"},

--- a/internal/params/envs.go
+++ b/internal/params/envs.go
@@ -8,6 +8,7 @@ const (
 	ProxyTypeEnv                        = "CX_PROXY_AUTH_TYPE"
 	ProxyDomainEnv                      = "CX_PROXY_NTLM_DOMAIN"
 	BaseAuthURIEnv                      = "CX_BASE_AUTH_URI"
+	ScaToolEnv                          = "SCA_TOOL"
 	AstAPIKeyEnv                        = "CX_APIKEY"
 	AccessKeyIDEnv                      = "CX_CLIENT_ID"
 	AccessKeySecretEnv                  = "CX_CLIENT_SECRET"

--- a/internal/params/envs.go
+++ b/internal/params/envs.go
@@ -8,7 +8,7 @@ const (
 	ProxyTypeEnv                        = "CX_PROXY_AUTH_TYPE"
 	ProxyDomainEnv                      = "CX_PROXY_NTLM_DOMAIN"
 	BaseAuthURIEnv                      = "CX_BASE_AUTH_URI"
-	ScaToolEnv                          = "SCA_TOOL"
+	ScaToolEnv                          = "SCA_RESOLVER"
 	AstAPIKeyEnv                        = "CX_APIKEY"
 	AccessKeyIDEnv                      = "CX_CLIENT_ID"
 	AccessKeySecretEnv                  = "CX_CLIENT_SECRET"

--- a/internal/params/keys.go
+++ b/internal/params/keys.go
@@ -11,6 +11,7 @@ var (
 	ProxyDomainKey                      = strings.ToLower(ProxyDomainEnv)
 	BaseAuthURIKey                      = strings.ToLower(BaseAuthURIEnv)
 	AstAPIKey                           = strings.ToLower(AstAPIKeyEnv)
+	ScaToolKey                          = strings.ToLower(ScaToolEnv)
 	ScansPathKey                        = strings.ToLower(ScansPathEnv)
 	AgentNameKey                        = strings.ToLower(AgentNameEnv)
 	ProjectsPathKey                     = strings.ToLower(ProjectsPathEnv)

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -50,6 +50,7 @@ func TestNoWaitScan(t *testing.T) {
 
 // Test ScaResolver environment variable, this is a nop test
 func TestScaResolverEnv(t *testing.T) {
+	scanID := ""
 	deleteScanCommand := createASTIntegrationTestCommand(t)
 	err := execute(
 		deleteScanCommand,
@@ -61,6 +62,7 @@ func TestScaResolverEnv(t *testing.T) {
 
 // Test ScaResolver environment variable, this is a nop test
 func TestScaResolverAdd(t *testing.T) {
+	scanID := ""
 	deleteScanCommand := createASTIntegrationTestCommand(t)
 	err := execute(
 		deleteScanCommand,

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -49,7 +49,7 @@ func TestNoWaitScan(t *testing.T) {
 }
 
 // Test ScaResolver environment variable, this is a nop test
-func TestScaResolverEnv(t *testing.T) {)
+func TestScaResolverEnv(t *testing.T) {
 	assert.Assert(t, true, "ScaResolver test should pass")
 }
 

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -48,66 +48,6 @@ func TestNoWaitScan(t *testing.T) {
 	executeScanTest(t, projectID, scanID, map[string]string{})
 }
 
-// Test ScaResolver environment variable, this is a nop test
-func TestScaResolverEnv(t *testing.T) {
-	scanID := ""
-	deleteScanCommand := createASTIntegrationTestCommand(t)
-	err := execute(
-		deleteScanCommand,
-		"scan", "delete",
-		flag(commands.ScanIDFlag), scanID,
-	)
-	assert.Error(t, err, "Deleting a scan should pass")
-}
-
-// Test ScaResolver environment variable, this is a nop test
-func TestScaResolverAdd(t *testing.T) {
-	scanID := ""
-	deleteScanCommand := createASTIntegrationTestCommand(t)
-	err := execute(
-		deleteScanCommand,
-		"scan", "delete",
-		flag(commands.ScanIDFlag), scanID,
-	)
-	assert.Error(t, err, "Deleting a scan should pass")
-}
-
-// Test ScaResolver environment variable, this is a nop test
-func TestScaResolverAddPt2(t *testing.T) {
-	scanID := ""
-	deleteScanCommand := createASTIntegrationTestCommand(t)
-	err := execute(
-		deleteScanCommand,
-		"scan", "delete",
-		flag(commands.ScanIDFlag), scanID,
-	)
-	assert.Error(t, err, "Deleting a scan should pass")
-}
-
-// Test ScaResolver environment variable, this is a nop test
-func TestScaResolverAddPt3(t *testing.T) {
-	scanID := ""
-	deleteScanCommand := createASTIntegrationTestCommand(t)
-	err := execute(
-		deleteScanCommand,
-		"scan", "delete",
-		flag(commands.ScanIDFlag), scanID,
-	)
-	assert.Error(t, err, "Deleting a scan should pass")
-}
-
-// Test ScaResolver environment variable, this is a nop test
-func TestScaResolverAddPt4(t *testing.T) {
-	scanID := ""
-	deleteScanCommand := createASTIntegrationTestCommand(t)
-	err := execute(
-		deleteScanCommand,
-		"scan", "delete",
-		flag(commands.ScanIDFlag), scanID,
-	)
-	assert.Error(t, err, "Deleting a scan should pass")
-}
-
 // Perform an initial scan with complete sources and an incremental scan with a smaller wait time
 func TestIncrementalScan(t *testing.T) {
 	projectName := fmt.Sprintf("integration_test_incremental_%s", uuid.New().String())

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -60,18 +60,6 @@ func TestScaResolverEnv(t *testing.T) {
 	executeScanTest(t, projectID, scanID, map[string]string{})
 }
 
-// Test ScaResolver environment variable, this is a nop test
-func TestScaResolverAdd(t *testing.T) {
-	scanID := ""
-	deleteScanCommand := createASTIntegrationTestCommand(t)
-	err := execute(
-		deleteScanCommand,
-		"scan", "delete",
-		flag(commands.ScanIDFlag), scanID,
-	)
-	assert.Error(t, err, "Deleting a scan should pass")
-}
-
 // Perform an initial scan with complete sources and an incremental scan with a smaller wait time
 func TestIncrementalScan(t *testing.T) {
 	projectName := fmt.Sprintf("integration_test_incremental_%s", uuid.New().String())

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -48,6 +48,30 @@ func TestNoWaitScan(t *testing.T) {
 	executeScanTest(t, projectID, scanID, map[string]string{})
 }
 
+// Test ScaResolver environment variable, this is a nop test
+func TestScaResolverEnv(t *testing.T) {
+	scanID, projectID := createScanNoWaitWithResolver(t, Dir, map[string]string{})
+	defer deleteProject(t, projectID)
+	assert.Assert(
+		t,
+		pollScanUntilStatus(t, scanID, scansApi.ScanCompleted, FullScanWait, ScanPollSleep),
+		"Polling should complete when resolver used.",
+	)
+	executeScanTest(t, projectID, scanID, map[string]string{})
+}
+
+// Test ScaResolver environment variable, this is a nop test
+func TestScaResolverAdd(t *testing.T) {
+	scanID := ""
+	deleteScanCommand := createASTIntegrationTestCommand(t)
+	err := execute(
+		deleteScanCommand,
+		"scan", "delete",
+		flag(commands.ScanIDFlag), scanID,
+	)
+	assert.Error(t, err, "Deleting a scan should pass")
+}
+
 // Perform an initial scan with complete sources and an incremental scan with a smaller wait time
 func TestIncrementalScan(t *testing.T) {
 	projectName := fmt.Sprintf("integration_test_incremental_%s", uuid.New().String())
@@ -172,6 +196,10 @@ func createScan(t *testing.T, source string, tags map[string]string) (string, st
 
 func createScanNoWait(t *testing.T, source string, tags map[string]string) (string, string) {
 	return executeCreateScan(t, append(getCreateArgs(source, tags), "--nowait"))
+}
+
+func createScanNoWaitWithResolver(t *testing.T, source string, tags map[string]string) (string, string) {
+	return executeCreateScan(t, append(getCreateArgs(source, tags), "--nowait", "--sca-resolver", "nop"))
 }
 
 func createScanIncremental(t *testing.T, source string, name string, tags map[string]string) (string, string) {

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -48,6 +48,18 @@ func TestNoWaitScan(t *testing.T) {
 	executeScanTest(t, projectID, scanID, map[string]string{})
 }
 
+// Test ScaResolver environment variable, this is a nop test
+func TestScaResolverEnv(t *testing.T) {
+	runScaResolver(sourceDir)
+	assert.Assert(t, true, "ScaResolver test should pass")
+}
+
+// Test ScaResolver environment variable, this is a nop test
+func TestScaResolverAdd(t *testing.T) {
+	_ = addScaResults(nil)
+	assert.Assert(t, true, "ScaResolver test should pass")
+}
+
 // Perform an initial scan with complete sources and an incremental scan with a smaller wait time
 func TestIncrementalScan(t *testing.T) {
 	projectName := fmt.Sprintf("integration_test_incremental_%s", uuid.New().String())

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -50,42 +50,24 @@ func TestNoWaitScan(t *testing.T) {
 
 // Test ScaResolver environment variable, this is a nop test
 func TestScaResolverEnv(t *testing.T) {
-	scanFilter := fmt.Sprintf("scan-ids=%s", scanID)
-
-	getCommand, outputBuffer := createRedirectedTestCommand(t)
+	deleteScanCommand := createASTIntegrationTestCommand(t)
 	err := execute(
-		getCommand,
-		"scan", "list",
-		flag(commands.FormatFlag), util.FormatJSON,
-		flag(commands.FilterFlag), scanFilter,
+		deleteScanCommand,
+		"scan", "delete",
+		flag(commands.ScanIDFlag), scanID,
 	)
-	assert.NilError(t, err, "Getting the scan should pass")
-
-	// Read response from buffer
-	var scanList []scansRESTApi.ScanResponseModel
-	_ = unmarshall(t, outputBuffer, &scanList, "Reading scan response JSON should pass")
-
-	return scanList
+	assert.Error(t, err, "Deleting a scan should pass")
 }
 
 // Test ScaResolver environment variable, this is a nop test
 func TestScaResolverAdd(t *testing.T) {
-	scanFilter := fmt.Sprintf("scan-ids=%s", scanID)
-
-	getCommand, outputBuffer := createRedirectedTestCommand(t)
+	deleteScanCommand := createASTIntegrationTestCommand(t)
 	err := execute(
-		getCommand,
-		"scan", "list",
-		flag(commands.FormatFlag), util.FormatJSON,
-		flag(commands.FilterFlag), scanFilter,
+		deleteScanCommand,
+		"scan", "delete",
+		flag(commands.ScanIDFlag), scanID,
 	)
-	assert.NilError(t, err, "Getting the scan should pass")
-
-	// Read response from buffer
-	var scanList []scansRESTApi.ScanResponseModel
-	_ = unmarshall(t, outputBuffer, &scanList, "Reading scan response JSON should pass")
-
-	return scanList
+	assert.Error(t, err, "Deleting a scan should pass")
 }
 
 // Perform an initial scan with complete sources and an incremental scan with a smaller wait time

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -50,12 +50,42 @@ func TestNoWaitScan(t *testing.T) {
 
 // Test ScaResolver environment variable, this is a nop test
 func TestScaResolverEnv(t *testing.T) {
-	assert.Assert(t, true, "ScaResolver test should pass")
+	scanFilter := fmt.Sprintf("scan-ids=%s", scanID)
+
+	getCommand, outputBuffer := createRedirectedTestCommand(t)
+	err := execute(
+		getCommand,
+		"scan", "list",
+		flag(commands.FormatFlag), util.FormatJSON,
+		flag(commands.FilterFlag), scanFilter,
+	)
+	assert.NilError(t, err, "Getting the scan should pass")
+
+	// Read response from buffer
+	var scanList []scansRESTApi.ScanResponseModel
+	_ = unmarshall(t, outputBuffer, &scanList, "Reading scan response JSON should pass")
+
+	return scanList
 }
 
 // Test ScaResolver environment variable, this is a nop test
 func TestScaResolverAdd(t *testing.T) {
-	assert.Assert(t, true, "ScaResolver test should pass")
+	scanFilter := fmt.Sprintf("scan-ids=%s", scanID)
+
+	getCommand, outputBuffer := createRedirectedTestCommand(t)
+	err := execute(
+		getCommand,
+		"scan", "list",
+		flag(commands.FormatFlag), util.FormatJSON,
+		flag(commands.FilterFlag), scanFilter,
+	)
+	assert.NilError(t, err, "Getting the scan should pass")
+
+	// Read response from buffer
+	var scanList []scansRESTApi.ScanResponseModel
+	_ = unmarshall(t, outputBuffer, &scanList, "Reading scan response JSON should pass")
+
+	return scanList
 }
 
 // Perform an initial scan with complete sources and an incremental scan with a smaller wait time

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -72,6 +72,42 @@ func TestScaResolverAdd(t *testing.T) {
 	assert.Error(t, err, "Deleting a scan should pass")
 }
 
+// Test ScaResolver environment variable, this is a nop test
+func TestScaResolverAddPt2(t *testing.T) {
+	scanID := ""
+	deleteScanCommand := createASTIntegrationTestCommand(t)
+	err := execute(
+		deleteScanCommand,
+		"scan", "delete",
+		flag(commands.ScanIDFlag), scanID,
+	)
+	assert.Error(t, err, "Deleting a scan should pass")
+}
+
+// Test ScaResolver environment variable, this is a nop test
+func TestScaResolverAddPt3(t *testing.T) {
+	scanID := ""
+	deleteScanCommand := createASTIntegrationTestCommand(t)
+	err := execute(
+		deleteScanCommand,
+		"scan", "delete",
+		flag(commands.ScanIDFlag), scanID,
+	)
+	assert.Error(t, err, "Deleting a scan should pass")
+}
+
+// Test ScaResolver environment variable, this is a nop test
+func TestScaResolverAddPt4(t *testing.T) {
+	scanID := ""
+	deleteScanCommand := createASTIntegrationTestCommand(t)
+	err := execute(
+		deleteScanCommand,
+		"scan", "delete",
+		flag(commands.ScanIDFlag), scanID,
+	)
+	assert.Error(t, err, "Deleting a scan should pass")
+}
+
 // Perform an initial scan with complete sources and an incremental scan with a smaller wait time
 func TestIncrementalScan(t *testing.T) {
 	projectName := fmt.Sprintf("integration_test_incremental_%s", uuid.New().String())

--- a/test/integration/scan_test.go
+++ b/test/integration/scan_test.go
@@ -49,14 +49,12 @@ func TestNoWaitScan(t *testing.T) {
 }
 
 // Test ScaResolver environment variable, this is a nop test
-func TestScaResolverEnv(t *testing.T) {
-	runScaResolver(sourceDir)
+func TestScaResolverEnv(t *testing.T) {)
 	assert.Assert(t, true, "ScaResolver test should pass")
 }
 
 // Test ScaResolver environment variable, this is a nop test
 func TestScaResolverAdd(t *testing.T) {
-	_ = addScaResults(nil)
 	assert.Assert(t, true, "ScaResolver test should pass")
 }
 


### PR DESCRIPTION
Added SCA Resolver support. The resolver must be correctly configured on your system for this to work.

Assuming the resolver is present you can trigger it in one of the following two ways:

- Set the environment variable SCA_RESOLVER to point to the executable.
- Pass the path of the executable to the (scan create) parameter (--sca-resolver <path>).

